### PR TITLE
Release 2.0.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "SwiftProtobuf",
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
-          "branch": "1.13.0",
+          "branch": null,
           "revision": "426bef0ddfdc6449b7bd1418baafad6bbc56110b",
-          "version": null
+          "version": "1.13.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(
             name: "SwiftProtobuf",
             url: "https://github.com/apple/swift-protobuf.git",
-            .revision("1.13.0")
+            .exact("1.13.0")
         ),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ addCheckin | Stores a check-in given arrival time, departure time and the venue 
 updateCheckin | Updates a checkin that has previously been stored | `updateCheckin(checkinId: String, venueInfo: VenueInfo, newArrivalTime: Date, newDepartureTime: Date) -> Result<String, CrowdNotifierError>`
 checkForMatches | Given a set of published events with a known infected visitor, stores and returns those locally stored check-ins that overlap with one of the problematic events | `func checkForMatches(publishedSKs: [ProblematicEventInfo]) -> [ExposureEvent]`
 getExposureEvents | Returns all currently stored check-ins that have previously matched a problematic event | `getExposureEvents() -> [ExposureEvent]`
+removeExposure | Remove a exposure from the exposure storage | `removeExposure(exposure: ExposureEvent)`
 cleanUpOldData | Removes all check-ins that are older than the specified number of days | `func cleanUpOldData(maxDaysToKeep: Int)`
 
 

--- a/Sources/CrowdNotifierSDK/CrowdNotifier.swift
+++ b/Sources/CrowdNotifierSDK/CrowdNotifier.swift
@@ -46,6 +46,11 @@ public enum CrowdNotifier {
         return instance.getExposureEvents()
     }
 
+    public static func removeExposure(exposure: ExposureEvent) {
+        instancePrecondition()
+        return instance.removeExposure(exposure: exposure)
+    }
+
     public static func cleanUpOldData(maxDaysToKeep: Int) {
         instancePrecondition()
         instance.cleanUpOldData(maxDaysToKeep: maxDaysToKeep)

--- a/Sources/CrowdNotifierSDK/CrowdNotifierMain.swift
+++ b/Sources/CrowdNotifierSDK/CrowdNotifierMain.swift
@@ -73,6 +73,10 @@ class CrowdNotifierMain {
         return exposureStorage.exposureEvents
     }
 
+    func removeExposure(exposure: ExposureEvent) {
+        return exposureStorage.removeExposure(exposure)
+    }
+
     func cleanUpOldData(maxDaysToKeep: Int) {
         checkinStorage.cleanUpOldData(maxDaysToKeep: maxDaysToKeep)
         exposureStorage.cleanUpOldData(maxDaysToKeep: maxDaysToKeep)

--- a/Sources/CrowdNotifierSDK/Exposure/ExposureStorage.swift
+++ b/Sources/CrowdNotifierSDK/Exposure/ExposureStorage.swift
@@ -23,6 +23,10 @@ class ExposureStorage {
         exposureEvents = events
     }
 
+    func removeExposure(_ exposure: ExposureEvent) {
+        exposureEvents = exposureEvents.filter { $0 != exposure }
+    }
+
     func cleanUpOldData(maxDaysToKeep: Int) {
         guard maxDaysToKeep > 0 else {
             exposureEvents = []


### PR DESCRIPTION
This minor release adds two improvements:

- Exposures can now be manually removed
- Integration via SPM now works as expected because `swift-protobuf` is now required via a version-based requirement.