### PR TITLE
Match overlap parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ init | Initializes the SDK and configures it | `func initialize()`
 getVenueInfo | Returns information about the data contained in a QR code, or an error if the QR code does not have a valid format or does not match the expected base URL | `getVenueInfo(qrCode: String, baseUrl: String) -> Result<VenueInfo, CrowdNotifierError>`
 addCheckin | Stores a check-in given arrival time, departure time and the venue information. Returns the id of the stored entry. | `addCheckin(venueInfo: VenueInfo, arrivalTime: Date, departureTime: Date) -> Result<String, CrowdNotifierError>`
 updateCheckin | Updates a checkin that has previously been stored | `updateCheckin(checkinId: String, venueInfo: VenueInfo, newArrivalTime: Date, newDepartureTime: Date) -> Result<String, CrowdNotifierError>`
-checkForMatches | Given a set of published events with a known infected visitor, stores and returns those locally stored check-ins that overlap with one of the problematic events | `func checkForMatches(publishedSKs: [ProblematicEventInfo]) -> [ExposureEvent]`
+checkForMatches | Given a set of published events with a known infected visitor and optionally a required minimum overlap, stores and returns those locally stored check-ins that overlap with one of the problematic events | `func checkForMatches(publishedSKs: [ProblematicEventInfo], requiredOverlap: TimeInterval = 0) -> [ExposureEvent]`
 getExposureEvents | Returns all currently stored check-ins that have previously matched a problematic event | `getExposureEvents() -> [ExposureEvent]`
 removeExposure | Remove a exposure from the exposure storage | `removeExposure(exposure: ExposureEvent)`
 cleanUpOldData | Removes all check-ins that are older than the specified number of days | `func cleanUpOldData(maxDaysToKeep: Int)`

--- a/Sources/CrowdNotifierSDK/CrowdNotifier.swift
+++ b/Sources/CrowdNotifierSDK/CrowdNotifier.swift
@@ -50,9 +50,9 @@ public enum CrowdNotifier {
         return instance.hasCheckins()
     }
 
-    public static func checkForMatches(problematicEventInfos: [ProblematicEventInfo]) -> [ExposureEvent] {
+    public static func checkForMatches(problematicEventInfos: [ProblematicEventInfo], requiredOverlap: TimeInterval = 0) -> [ExposureEvent] {
         instancePrecondition()
-        return instance.checkForMatches(problematicEventInfos: problematicEventInfos)
+        return instance.checkForMatches(problematicEventInfos: problematicEventInfos, requiredOverlap: requiredOverlap)
     }
 
     public static func generateQRCodeString(baseUrl: String, masterPublicKey: Bytes, description: String, address: String, startTimestamp: Date, endTimestamp: Date, countryData: Data?) -> Result<(VenueInfo, String), CrowdNotifierError> {

--- a/Sources/CrowdNotifierSDK/CrowdNotifierMain.swift
+++ b/Sources/CrowdNotifierSDK/CrowdNotifierMain.swift
@@ -61,14 +61,15 @@ class CrowdNotifierMain {
         return !checkinStorage.encryptedVenueVisits.isEmpty
     }
 
-    func checkForMatches(problematicEventInfos: [ProblematicEventInfo]) -> [ExposureEvent] {
+    func checkForMatches(problematicEventInfos: [ProblematicEventInfo], requiredOverlap: TimeInterval) -> [ExposureEvent] {
         var allExposureEvents = ExposureStorage.shared.exposureEvents
 
         for eventInfo in problematicEventInfos {
             // Only check visits with the same day as the problematic event
             // eventInfo.day is in seconds, so we need to multiply daysSince1970 by 24 * 60 * 60
             let matches = CryptoUtils.searchAndDecryptMatches(eventInfo: eventInfo,
-                                                              venueVisits: checkinStorage.encryptedVenueVisits.filter { $0.daysSince1970 * 24 * 60 * 60 == eventInfo.day })
+                                                              venueVisits: checkinStorage.encryptedVenueVisits.filter { $0.daysSince1970 * 24 * 60 * 60 == eventInfo.day },
+                                                              requiredOverlap: requiredOverlap)
 
             for match in matches {
                 // Don't add the same checkin twice

--- a/Sources/CrowdNotifierSDK/Crypto/CryptoUtils.swift
+++ b/Sources/CrowdNotifierSDK/Crypto/CryptoUtils.swift
@@ -49,7 +49,7 @@ final class CryptoUtils {
         return encryptedVisits
     }
 
-    public static func searchAndDecryptMatches(eventInfo: ProblematicEventInfo, venueVisits: [EncryptedVenueVisit]) -> [ExposureEvent] {
+    public static func searchAndDecryptMatches(eventInfo: ProblematicEventInfo, venueVisits: [EncryptedVenueVisit], requiredOverlap: TimeInterval) -> [ExposureEvent] {
         var exposureEvents = [ExposureEvent]()
 
         for visit in venueVisits {
@@ -75,8 +75,14 @@ final class CryptoUtils {
                                           countryData: associatedData.countryData)
 
                 // Check if time of visit actually overlaps with the problematic timeslot
-                if event.departureTime >= startDate, event.arrivalTime <= endDate {
-                    exposureEvents.append(event)
+                if requiredOverlap >= 0 {
+                    if startDate.addingTimeInterval(requiredOverlap) <= event.departureTime || event.arrivalTime.addingTimeInterval(requiredOverlap) <= endDate {
+                        exposureEvents.append(event)
+                    }
+                } else {
+                    if event.departureTime >= startDate, event.arrivalTime <= endDate {
+                        exposureEvents.append(event)
+                    }
                 }
             }
         }

--- a/Sources/CrowdNotifierSDK/Crypto/CryptoUtils.swift
+++ b/Sources/CrowdNotifierSDK/Crypto/CryptoUtils.swift
@@ -75,14 +75,9 @@ final class CryptoUtils {
                                           countryData: associatedData.countryData)
 
                 // Check if time of visit actually overlaps with the problematic timeslot
-                if requiredOverlap >= 0 {
-                    if startDate.addingTimeInterval(requiredOverlap) <= event.departureTime || event.arrivalTime.addingTimeInterval(requiredOverlap) <= endDate {
-                        exposureEvents.append(event)
-                    }
-                } else {
-                    if event.departureTime >= startDate, event.arrivalTime <= endDate {
-                        exposureEvents.append(event)
-                    }
+                let overlap = max(requiredOverlap, 0)
+                if max(startDate, event.arrivalTime).addingTimeInterval(overlap) <= min(endDate, event.departureTime) {
+                    exposureEvents.append(event)
                 }
             }
         }


### PR DESCRIPTION
This PR adds an optional `requiredOverlap` parameter to the `checkForMatches` function that defines the minimum time interval a checkin needs to overlap with a problematic event to be considered a match. The default is 0.